### PR TITLE
Use `_alloca` on MSVC

### DIFF
--- a/alloca_.c
+++ b/alloca_.c
@@ -1,7 +1,16 @@
 #include <stddef.h>
 #include <inttypes.h>
 
-void* c_with_alloca(size_t size,void* (*callback) (uint8_t*,void*),void* data) {
+#ifdef _MSC_VER
+#include <malloc.h>
+#endif
+
+void *c_with_alloca(size_t size, void *(*callback)(uint8_t *, void *), void* data) {
+#ifdef _MSC_VER
+    uint8_t *buffer = _alloca(size);
+#else
     uint8_t buffer[size];
-    return callback(&buffer[0],data);
+#endif
+
+    return callback(&buffer[0], data);
 }


### PR DESCRIPTION
I tried using this library on Windows 10 and it failed to compile with the following error:

```
PS > cargo check
   Compiling alloca v0.3.3
error: failed to run custom build command for `alloca v0.3.3`

Caused by:
  process didn't exit successfully: `D:\Workspace\Rust\target\debug\build\alloca-35b065238ea1691c\build-script-build` (exit code: 1)
  --- stdout
  TARGET = Some("x86_64-pc-windows-msvc")
  HOST = Some("x86_64-pc-windows-msvc")
  CC_x86_64-pc-windows-msvc = None
  CC_x86_64_pc_windows_msvc = None
  HOST_CC = None
  CC = None
  CFLAGS_x86_64-pc-windows-msvc = None
  CFLAGS_x86_64_pc_windows_msvc = None
  HOST_CFLAGS = None
  CFLAGS = None
  CRATE_CC_NO_DEFAULTS = None
  CARGO_CFG_TARGET_FEATURE = Some("fxsr,sse,sse2")
  DEBUG = Some("true")
  running: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.28.29910\\bin\\HostX64\\x64\\cl.exe" "-nologo" "-MD" "-O2" "-Z7" "-Brepro" "-W4" "-FoD:\\Workspace\\Rust\\target\\debug\\build\\alloca-994b32a5b75cdee9\\out\\alloca_.o" "-c" "alloca_.c"
  alloca_.c
  alloca_.c(5): error C2057: expected constant expression
  alloca_.c(5): error C2466: cannot allocate an array of constant size 0
  alloca_.c(5): error C2133: 'buffer': unknown size
  exit code: 2

  --- stderr


  error occurred: Command "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.28.29910\\bin\\HostX64\\x64\\cl.exe" "-nologo" "-MD" "-O2" "-Z7" "-Brepro" "-W4" "-FoD:\\Workspace\\Rust\\target\\debug\\build\\alloca-994b32a5b75cdee9\\out\\alloca_.o" "-c" "alloca_.c" with args "cl.exe" did not execute successfully (status code exit code: 2).
```

As it turns out, MSVC is not C99 compliant and therefore does not support the variable-length arrays which this library relies on.

It does however support dynamically sized stack allocations via its build-in [`_alloca`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/alloca?view=msvc-160) function.

This PR changes the C code to use `_alloca` when being built on MSVC and VLAs on any other platform.